### PR TITLE
feat: add middleware for auth & validation

### DIFF
--- a/lib/api/middleware.ts
+++ b/lib/api/middleware.ts
@@ -1,0 +1,106 @@
+﻿import { HttpMethod, MethodHandlers } from "@/types/api";
+import { $Enums } from "@/generated/prisma";
+import { z, ZodError } from "zod";
+import Role = $Enums.Role;
+import { getServerSession } from "next-auth/next";
+import { authOptions as serverAuthOptions } from "@/pages/api/auth/[...nextauth]";
+import { Session } from "next-auth";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const methods: HttpMethod[] = ["GET", "POST", "PUT", "DELETE", "PATCH"];
+
+interface ValidationOptions {
+  body?: z.ZodSchema;
+  query?: z.ZodSchema;
+}
+
+interface MethodOptions {
+  auth?: {
+    [key in HttpMethod]?: {
+      required?: boolean;
+      role?: Role | Role[];
+    };
+  };
+  validation?: {
+    [key in HttpMethod]?: ValidationOptions;
+  };
+}
+
+const validateRole = ({ user }: Session, requiredRole?: Role[] | Role) => {
+  const userRole = user.role;
+
+  if (!requiredRole) return true;
+  if (!userRole) return false;
+
+  if (Array.isArray(requiredRole)) {
+    return requiredRole.includes(userRole);
+  }
+
+  return userRole === requiredRole;
+};
+
+const validateRequest = async (
+  req: NextApiRequest,
+  schema?: ValidationOptions,
+) => {
+  if (!schema) return;
+
+  if (schema.body) {
+    req.body = await schema.body.parseAsync(req.body);
+  }
+  if (schema.query) {
+    req.query = await schema.query.parseAsync(req.query);
+  }
+};
+
+export function createMethodHandler(
+  handlers: MethodHandlers,
+  options: MethodOptions = {},
+) {
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    const session = await getServerSession(req, res, serverAuthOptions);
+    const method = req.method as HttpMethod;
+    const handler = handlers[method];
+
+    if (!handler) {
+      const allowedMethods = methods.filter((method) =>
+        Object.keys(handlers).includes(method),
+      );
+      res.setHeader("Allow", allowedMethods);
+      return res.status(405).json({ error: `Method ${method} Not Allowed` });
+    }
+
+    const authOptions = options.auth?.[method];
+
+    if (authOptions?.required) {
+      if (!session) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      // Role check
+      if (authOptions.role && !validateRole(session, authOptions.role)) {
+        return res.status(403).json({ error: "Insufficient permissions" });
+      }
+    }
+
+    const validationOptions = options.validation?.[method];
+
+    if (validationOptions) {
+      try {
+        await validateRequest(req, validationOptions);
+      } catch (error) {
+        if (error instanceof ZodError) {
+          return res.status(400).json({
+            error: "Validation Error",
+            details: error.errors,
+          });
+        }
+
+        return res.status(500).json({ error: "Internal server error" });
+      }
+    }
+
+    // TODO: Add error 500 error handling here
+    return handler(req, res, session || undefined);
+  };
+}

--- a/lib/api/reports/createReport.ts
+++ b/lib/api/reports/createReport.ts
@@ -1,0 +1,74 @@
+﻿import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/prisma";
+import ReportCreateInput = Prisma.ReportCreateInput;
+import { z } from "zod";
+
+export const createReportSchema = z.object({
+  speaker: z.string(),
+  sentence: z.string(),
+  npcid: z.string(),
+  skeletonid: z.string(),
+  folder: z.string(),
+  user: z.string(),
+  comment: z.string().optional(),
+  body: z.string(),
+  gender: z.string(),
+  race: z.string(),
+  tribe: z.string(),
+  eyes: z.string(),
+});
+
+export default async function createReport(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // Create a new report
+  try {
+    const {
+      speaker,
+      sentence,
+      npcid,
+      skeletonid,
+      body,
+      gender,
+      race,
+      tribe,
+      eyes,
+      folder,
+      user,
+      comment,
+    } = req.body;
+
+    const data: ReportCreateInput = {
+      speaker,
+      sentence,
+      npcId: npcid,
+      skeletonId: skeletonid,
+      body,
+      gender,
+      race,
+      tribe,
+      eyes,
+      folder,
+      user,
+      comment,
+    };
+
+    // Return the existing entry if it already exists
+    const existingEntry = await prisma.report.findFirst({
+      where: { ...data },
+    });
+
+    if (existingEntry) {
+      return res.status(200).json(existingEntry);
+    }
+
+    const report = await prisma.report.create({ data });
+
+    return res.status(201).json(report);
+  } catch (error) {
+    console.error("Error creating report:", error);
+    return res.status(500).json({ error: "Failed to create report" });
+  }
+}

--- a/lib/api/reports/deleteReport.ts
+++ b/lib/api/reports/deleteReport.ts
@@ -1,0 +1,23 @@
+﻿import { prisma } from "@/lib/prisma";
+import { NextApiRequest, NextApiResponse } from "next";
+
+export async function deleteReport(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const id = req.query?.id as string;
+
+    const report = await prisma.report.findUnique({
+      where: { id },
+    });
+
+    if (!report) {
+      return res.status(404).json({ error: "Report not found" });
+    }
+
+    await prisma.report.delete({ where: { id } });
+
+    return res.status(204).json({ message: "Report deleted" });
+  } catch (error) {
+    console.error("Error deleting report:", error);
+    return res.status(500).json({ error: "Failed to delete report" });
+  }
+}

--- a/lib/api/reports/getReport.ts
+++ b/lib/api/reports/getReport.ts
@@ -1,0 +1,26 @@
+﻿import { prisma } from "@/lib/prisma";
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+export const getReportQuerySchema = z.object({
+  id: z.string(),
+});
+
+export async function getReport(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const id = req.query?.id as string;
+
+    const report = await prisma.report.findUnique({
+      where: { id },
+    });
+
+    if (!report) {
+      return res.status(404).json({ error: "Report not found" });
+    }
+
+    return res.status(200).json(report);
+  } catch (error) {
+    console.error("Error getting report:", error);
+    return res.status(500).json({ error: "Failed to get report" });
+  }
+}

--- a/lib/api/reports/getReportList.ts
+++ b/lib/api/reports/getReportList.ts
@@ -1,0 +1,16 @@
+﻿import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "@/lib/prisma";
+
+export default async function getReportList(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // Get all reports
+  try {
+    const reports = await prisma.report.findMany();
+    return res.status(200).json(reports);
+  } catch (error) {
+    console.error("Error fetching reports:", error);
+    return res.status(500).json({ error: "Failed to fetch reports" });
+  }
+}

--- a/lib/api/reports/updateReport.ts
+++ b/lib/api/reports/updateReport.ts
@@ -1,0 +1,76 @@
+﻿import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/prisma";
+import { z } from "zod";
+import ReportUpdateInput = Prisma.ReportUpdateInput;
+
+export const updateReportSchema = z.object({
+  speaker: z.string().optional(),
+  sentence: z.string().optional(),
+  npcid: z.string().optional(),
+  skeletonid: z.string().optional(),
+  folder: z.string().optional(),
+  user: z.string().optional(),
+  comment: z.string().optional(),
+  body: z.string().optional(),
+  gender: z.string().optional(),
+  race: z.string().optional(),
+  tribe: z.string().optional(),
+  eyes: z.string().optional(),
+});
+
+export default async function updateReport(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // Create a new report
+  try {
+    const id = req.query?.id as string;
+
+    const {
+      speaker,
+      sentence,
+      npcid,
+      skeletonid,
+      body,
+      gender,
+      race,
+      tribe,
+      eyes,
+      folder,
+      user,
+      comment,
+    } = req.body;
+
+    const data: ReportUpdateInput = {
+      speaker,
+      sentence,
+      npcId: npcid,
+      skeletonId: skeletonid,
+      body,
+      gender,
+      race,
+      tribe,
+      eyes,
+      folder,
+      user,
+      comment,
+    };
+
+    // Check if entry exists
+    const report = await prisma.report.findUnique({
+      where: { id },
+    });
+
+    if (!report) {
+      return res.status(404).json({ error: "Report not found" });
+    }
+
+    const updatedReport = await prisma.report.update({ data, where: { id } });
+
+    return res.status(200).json(updatedReport);
+  } catch (error) {
+    console.error("Error creating report:", error);
+    return res.status(500).json({ error: "Failed to create report" });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
         "typescript": "^5.8.3",
         "undici-types": "^6.19.8",
         "uuid": "^8.3.2",
-        "yallist": "^4.0.0"
+        "yallist": "^4.0.0",
+        "zod": "^3.25.46"
       },
       "devDependencies": {
         "@types/node": "22.15.29",
@@ -1331,6 +1332,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.46",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.46.tgz",
+      "integrity": "sha512-IqRxcHEIjqLd4LNS/zKffB3Jzg3NwqJxQQ0Ns7pdrvgGkwQsEBdEQcOHaBVqvvZArShRzI39+aMST3FBGmTrLQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "typescript": "^5.8.3",
     "undici-types": "^6.19.8",
     "uuid": "^8.3.2",
-    "yallist": "^4.0.0"
+    "yallist": "^4.0.0",
+    "zod": "^3.25.46"
   },
   "devDependencies": {
     "@types/node": "22.15.29",

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,11 +1,10 @@
-﻿import NextAuth from 'next-auth';
-import DiscordProvider from 'next-auth/providers/discord';
-import { PrismaAdapter } from '@next-auth/prisma-adapter';
-import { prisma } from '@/lib/prisma';
+﻿import NextAuth from "next-auth";
+import type { NextAuthOptions } from "next-auth";
+import DiscordProvider from "next-auth/providers/discord";
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import { prisma } from "@/lib/prisma";
 
-// For more information on each option (and a full list of options) go to
-// https://next-auth.js.org/configuration/options
-export default NextAuth({
+export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   // Configure one or more authentication providers
   providers: [
@@ -15,7 +14,7 @@ export default NextAuth({
       // Request additional permissions from Discord
       authorization: {
         params: {
-          scope: 'identify email guilds',
+          scope: "identify email guilds",
         },
       },
     }),
@@ -31,7 +30,7 @@ export default NextAuth({
 
   session: {
     // Use database strategy for sessions when using an adapter
-    strategy: 'database',
+    strategy: "database",
     // Seconds - How long until an idle session expires and is no longer valid
     maxAge: 30 * 24 * 60 * 60, // 30 days
   },
@@ -45,7 +44,7 @@ export default NextAuth({
 
   // You can define custom pages to override the built-in ones
   pages: {
-    signIn: '/', // Use the home page for sign in
+    signIn: "/", // Use the home page for sign in
     // signOut: '/auth/signout',
     // error: '/auth/error', // Error code passed in query string as ?error=
     // verifyRequest: '/auth/verify-request', // Used for check email page
@@ -57,7 +56,7 @@ export default NextAuth({
   callbacks: {
     async jwt({ token, account, profile }) {
       // Persist the Discord access_token to the token right after sign in
-      if (account?.provider === 'discord') {
+      if (account?.provider === "discord") {
         token.accessToken = account.access_token;
         token.discordProfile = profile;
       }
@@ -70,9 +69,9 @@ export default NextAuth({
         // TODO: Determine why types for name and image are being overwritten
         session.user = {
           ...user,
-          name: user.name || '',
-          image: user.image || '',
-        }
+          name: user.name || "",
+          image: user.image || "",
+        };
 
         // If we still have access to the token (during the transition), get the access token
         if (token?.accessToken) {
@@ -90,7 +89,7 @@ export default NextAuth({
   // Events are useful for logging
   events: {
     async signIn({ user, account, profile }) {
-      if (account?.provider === 'discord' && profile) {
+      if (account?.provider === "discord" && profile) {
         try {
           // Update user with Discord-specific information
           await prisma.user.update({
@@ -103,12 +102,16 @@ export default NextAuth({
             },
           });
         } catch (error) {
-          console.error('Error updating user with Discord data:', error);
+          console.error("Error updating user with Discord data:", error);
         }
       }
     },
   },
 
   // Enable debug messages in the console if you are having problems
-  debug: process.env.NODE_ENV === 'development',
-});
+  debug: process.env.NODE_ENV === "development",
+};
+
+// For more information on each option (and a full list of options) go to
+// https://next-auth.js.org/configuration/options
+export default NextAuth(authOptions);

--- a/pages/api/reports/[id].ts
+++ b/pages/api/reports/[id].ts
@@ -1,124 +1,35 @@
-﻿import { NextApiRequest, NextApiResponse } from 'next';
-import { prisma } from '@/lib/prisma';
-import { getSession } from 'next-auth/react';
-import {$Enums} from "@/generated/prisma";
+﻿import { $Enums } from "@/generated/prisma";
 import Role = $Enums.Role;
+import { createMethodHandler } from "@/lib/api/middleware";
+import { getReport, getReportQuerySchema } from "@/lib/api/reports/getReport";
+import updateReport, {
+  updateReportSchema,
+} from "@/lib/api/reports/updateReport";
+import { deleteReport } from "@/lib/api/reports/deleteReport";
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const session = await getSession({ req });
-
-  // Check if user is authenticated
-  if (!session) {
-    return res.status(401).json({ error: 'You must be signed in to access this endpoint' });
-  }
-
-  // Check if user is an admin
-  if (session.user.role !== Role.ADMIN) {
-    return res.status(403).json({ error: 'You must be an admin to perform this operation' })
-  }
-
-  // Get the report ID from the URL
-  const { id } = req.query;
-
-  if (!id || typeof id !== 'string') {
-    return res.status(400).json({ error: 'Invalid report ID' });
-  }
-
-  switch (req.method) {
-    case 'GET':
-      // Get a specific report by ID
-      try {
-        const report = await prisma.report.findUnique({
-          where: { id }
-        });
-
-        if (!report) {
-          return res.status(404).json({ error: 'Report not found' });
-        }
-
-        return res.status(200).json(report);
-      } catch (error) {
-        console.error('Error fetching report:', error);
-        return res.status(500).json({ error: 'Failed to fetch report' });
-      }
-
-    case 'PUT':
-      // Update a report
-      try {
-        const {
-          speaker,
-          sentence,
-          npcId,
-          skeletonId,
-          body,
-          gender,
-          race,
-          tribe,
-          eyes,
-          folder,
-          user,
-          comment
-        } = req.body;
-
-        // Check if report exists
-        const existingReport = await prisma.report.findUnique({
-          where: { id }
-        });
-
-        if (!existingReport) {
-          return res.status(404).json({ error: 'Report not found' });
-        }
-
-        // Update the report
-        const updatedReport = await prisma.report.update({
-          where: { id },
-          data: {
-            speaker,
-            sentence,
-            npcId,
-            skeletonId,
-            body,
-            gender,
-            race,
-            tribe,
-            eyes,
-            folder,
-            user,
-            comment
-          }
-        });
-
-        return res.status(200).json(updatedReport);
-      } catch (error) {
-        console.error('Error updating report:', error);
-        return res.status(500).json({ error: 'Failed to update report' });
-      }
-
-    case 'DELETE':
-      // Delete a report
-      try {
-        // Check if report exists
-        const existingReport = await prisma.report.findUnique({
-          where: { id }
-        });
-
-        if (!existingReport) {
-          return res.status(404).json({ error: 'Report not found' });
-        }
-
-        // Delete the report
-        await prisma.report.delete({
-          where: { id }
-        });
-
-        return res.status(204).send(null);
-      } catch (error) {
-        console.error('Error deleting report:', error);
-        return res.status(500).json({ error: 'Failed to delete report' });
-      }
-
-    default:
-      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
-      return res.status(405).json({ error: `Method ${req.method} Not Allowed` });
-  }
-}
+export default createMethodHandler(
+  {
+    GET: getReport,
+    PATCH: updateReport,
+    DELETE: deleteReport,
+  },
+  {
+    auth: {
+      GET: { required: false },
+      PATCH: { required: true, role: [Role.ADMIN] },
+      DELETE: { required: true, role: [Role.ADMIN] },
+    },
+    validation: {
+      GET: {
+        query: getReportQuerySchema,
+      },
+      PATCH: {
+        query: getReportQuerySchema,
+        body: updateReportSchema,
+      },
+      DELETE: {
+        query: getReportQuerySchema,
+      },
+    },
+  },
+);

--- a/pages/api/reports/index.ts
+++ b/pages/api/reports/index.ts
@@ -1,100 +1,23 @@
-﻿import { NextApiRequest, NextApiResponse } from "next";
-import { prisma } from "@/lib/prisma";
-import { Prisma, Report } from "@/generated/prisma";
-import ReportCreateInput = Prisma.ReportCreateInput;
+﻿import { createMethodHandler } from "@/lib/api/middleware";
+import getReportList from "@/lib/api/reports/getReportList";
+import createReport, {
+  createReportSchema,
+} from "@/lib/api/reports/createReport";
 
-type CreateReportDTO = Omit<Report, "id">;
-
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse,
-) {
-  switch (req.method) {
-    case "GET":
-      // Get all reports
-      try {
-        const reports = await prisma.report.findMany();
-        return res.status(200).json(reports);
-      } catch (error) {
-        console.error("Error fetching reports:", error);
-        return res.status(500).json({ error: "Failed to fetch reports" });
-      }
-
-    case "POST":
-      // Create a new report
-      try {
-        const {
-          speaker,
-          sentence,
-          npcid,
-          skeletonid,
-          body,
-          gender,
-          race,
-          tribe,
-          eyes,
-          folder,
-          user,
-          comment,
-        } = req.body;
-
-        // Validate required fields
-        const requiredFields = [
-          "speaker",
-          "sentence",
-          "npcid",
-          "skeletonid",
-          "body",
-          "gender",
-          "race",
-          "tribe",
-          "eyes",
-          "folder",
-          "user",
-        ];
-
-        for (const field of requiredFields) {
-          if (!req.body[field]) {
-            return res.status(400).json({ error: `${field} is required` });
-          }
-        }
-
-        const data: ReportCreateInput = {
-          speaker,
-          sentence,
-          npcId: npcid,
-          skeletonId: skeletonid,
-          body,
-          gender,
-          race,
-          tribe,
-          eyes,
-          folder,
-          user,
-          comment,
-        };
-
-        // Return the existing entry if it already exists
-        const existingEntry = await prisma.report.findFirst({
-          where: { ...data },
-        });
-
-        if (existingEntry) {
-          return res.status(200).json(existingEntry);
-        }
-
-        const report = await prisma.report.create({ data });
-
-        return res.status(201).json(report);
-      } catch (error) {
-        console.error("Error creating report:", error);
-        return res.status(500).json({ error: "Failed to create report" });
-      }
-
-    default:
-      res.setHeader("Allow", ["GET", "POST"]);
-      return res
-        .status(405)
-        .json({ error: `Method ${req.method} Not Allowed` });
-  }
-}
+export default createMethodHandler(
+  {
+    GET: getReportList,
+    POST: createReport,
+  },
+  {
+    auth: {
+      GET: { required: false },
+      POST: { required: false },
+    },
+    validation: {
+      POST: {
+        body: createReportSchema,
+      },
+    },
+  },
+);

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,12 @@
+﻿import { NextApiRequest, NextApiResponse } from "next";
+import { Session } from "next-auth";
+
+export type ApiHandler = (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  session?: Session,
+) => Promise<void> | void;
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+
+export type MethodHandlers = Partial<Record<HttpMethod, ApiHandler>>;


### PR DESCRIPTION
I wanted to abstract how we handle authentication, validation, (and maybe in the future rate limiting?) into a middleware you could pass handlers and options to.

The idea is to keep the logic of each endpoint encapsulated into its own function without mixing validation or authorization logic into it. Once the method handler has been invoked the method handler should rest assured it is meant to run. Keeping it simple.

Also, it encourages not having all of your route's handlers being present in 1 file which could become lengthy and unwieldy!

### Here's it in action:

Route 400 Validation Response:
![image](https://github.com/user-attachments/assets/4b46318b-eb81-461b-a38e-212aac8cfdaf)

200 POST Success:
![image](https://github.com/user-attachments/assets/bd9dbaed-eb7c-4f89-923b-35f4f347700e)

200 GET Success:
![image](https://github.com/user-attachments/assets/382d7885-e630-4c02-b85d-aee613cc7316)

404 GET Failure:
![image](https://github.com/user-attachments/assets/89598bf5-bf82-47cb-af81-8acbb20fcb81)

405 Invalid Method Failure:
![image](https://github.com/user-attachments/assets/32b148cb-5209-4fed-9f9d-5933e061a858)

401 Unauthorized:
![image](https://github.com/user-attachments/assets/50342958-7158-4c7e-bcc5-387ed2e6c6a7)
